### PR TITLE
Adesões e correções relacionadas a funcionalidade de retorno de json e status http code

### DIFF
--- a/api/helpers.php
+++ b/api/helpers.php
@@ -1,7 +1,10 @@
-<?php 
+<?php
 
 function responseJson(string $message, int $httpCode)
 {
+    header("Content-Type: application/json; charset=UTF-8");
+
     http_response_code($httpCode);
+
     echo json_encode(['mensagem' => $message]);
 }

--- a/api/helpers.php
+++ b/api/helpers.php
@@ -1,6 +1,6 @@
 <?php
 
-function responseJson(string $message, int $httpCode)
+function responseJson(string|array $message, int $httpCode)
 {
     header("Content-Type: application/json; charset=UTF-8");
 

--- a/api/read.php
+++ b/api/read.php
@@ -1,30 +1,28 @@
 <?php
 
-header("Content-Type: application/json; charset=UTF-8");
-$dados = json_decode($dados, true);
-
+include '../api/helpers.php';
 include "db.php";
 
-if($_SERVER['REQUEST_METHOD'] === 'POST'){
+$dados = json_decode(file_get_contents('php://input'), true);
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $connection = conectar();
     $selectDados = "SELECT * FROM livros";
     $resultado = $connection->query($selectDados);
 
-    if($resultado->num_rows > 0){
-        $livros = array();
+    if ($resultado->num_rows > 0) {
+        $livros = [];
 
         while($row = $resultado->fetch_assoc()){
             $livros[] = $row;
         }
-        echo json_encode($livros);
-    }else{
-        echo json_encode(array(["mensagem" => "Nenhum livro encontrado"]));
+
+        responseJson($dados, 200);
+    } else {
+        responseJson("Nenhum livro encontrado", 204);
     }
 
     $connection->close();
-
-}else{
-    echo json_encode(["mensagem" => "Error"]);
+} else {
+    responseJson('Error', 405);
 }
-
-?>

--- a/api/read.php
+++ b/api/read.php
@@ -17,7 +17,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $livros[] = $row;
         }
 
-        responseJson($dados, 200);
+        responseJson($livros, 200);
     } else {
         responseJson("Nenhum livro encontrado", 204);
     }

--- a/tests/checkJsonReturnFunction.php
+++ b/tests/checkJsonReturnFunction.php
@@ -1,0 +1,5 @@
+<?php
+
+include '../api/helpers.php';
+
+responseJson('Minha Mensagem', 200);


### PR DESCRIPTION
Olá, seguinte, primeiramente, adicinei a nossa função de retorno em JSON uma nova linha que estabelece que a página sempre terá o conteúdo do tipo JSON e a mensagem agora pode ser do tipo string e array.

Logo em seguida tomei a liberdade de alterar a sua rota read.php, onde a mesma agora está inicializando a variável dados e contém a nossa função, note que não preciso de emitir o resultado com 'echo', ele já se encontra dentro da função.

Por fim, criei uma nova pasta, muito útil, chamada 'tests', que no futuro pode ser colocada dentro do um .gitignore se você quiser restringir acesso aos seus testes, nela podemos criar arquivos específicos de testes, e encapsular e tratar possíveis erros. 

Um extra, caso tenha dúvidas sobre o que retornar dentro do HTTP Code, segue um link com todos os codes possíveis: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status

Qualquer dúvida pode perguntar nesse mesmo PR.